### PR TITLE
Hash instead of IP in traffic limiter

### DIFF
--- a/lib/trafficlimiter.php
+++ b/lib/trafficlimiter.php
@@ -79,7 +79,7 @@ class trafficlimiter extends persistence
      */
     public static function getIp()
     {
-        return $_SERVER[self::$_ipKey];
+        return md5($_SERVER[self::$_ipKey]);
     }
 
     /**


### PR DESCRIPTION
Simply use IP's hash instead of IP itself for traffic limiter.

I can also add salt if you agree to merge this idea.