### PR TITLE
Add a (disabled by default) .htaccess file to block out robots and other link scanning agents.

### DIFF
--- a/.htaccess.disabled
+++ b/.htaccess.disabled
@@ -1,0 +1,3 @@
+RewriteEngine on
+RewriteCond %{HTTP_USER_AGENT} ^.*(bot|spider|crawl|https?://|WhatsApp|SkypeUriPreview) [NC]
+RewriteRule .* - [R=403,L]


### PR DESCRIPTION
Most users of ZeroBin would not want to have their links indexed by a search bot due to privacy reasons. However, such indexing can occur in many ways. As an example, while sharing a link via Facebook, Skype or any other centralised IM services, bots from these services automatically visit the page. Pastes marked as "burn after reading" may also be removed as a result of these bots.

This pull request adds a disabled `.htaccess` file, which can be enabled if the system administrator wishes to, in order to block such robots and link scanning agents.