### PR TITLE
Force line breaks for long URL

### DIFF
--- a/css/bootstrap/zerobin.css
+++ b/css/bootstrap/zerobin.css
@@ -47,7 +47,7 @@ body.navbar-spacing {
 }
 
 #pastelink > a {
-	display: inline;
+	word-wrap: break-word;
 }
 
 #message {

--- a/css/bootstrap/zerobin.css
+++ b/css/bootstrap/zerobin.css
@@ -46,6 +46,10 @@ body.navbar-spacing {
 	display: inline;
 }
 
+#pastelink > a {
+	display: inline;
+}
+
 #message {
 	font-family: monospace;
 }


### PR DESCRIPTION
This fixes a display issue in mobile view where the long URL was outside of the window...

Only tested in browser with Bootstrap-Page theme. This issue may also affect other themes.