### PR TITLE
Fine-tune grammar.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Build Status](https://travis-ci.org/elrido/ZeroBin.svg?branch=master)](https://travis-ci.org/elrido/ZeroBin)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/094500f62abf4c9aa0c8a8a4520e4789)](https://www.codacy.com/app/ZeroBin/ZeroBin?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=elrido/ZeroBin&amp;utm_campaign=Badge_Grade)
 
-ZeroBin is a minimalist, opensource online pastebin where the server has zero 
+ZeroBin is a minimalist, open source online pastebin where the server has zero 
 knowledge of pasted data.
 
 Data is encrypted/decrypted in the browser using 256 bit AES.


### PR DESCRIPTION
My "OCD" kicked in. I believe "open source" is grammatically correct, so let us therefore use this rather than "opensource". It looks better too :)